### PR TITLE
remove vdso gettime section in patch

### DIFF
--- a/recipe/syscalls_rmv_boottime.patch
+++ b/recipe/syscalls_rmv_boottime.patch
@@ -92,29 +92,6 @@ index 86ed87b..28f522a 100644
                           PrintClockId);
  
  TEST(TimerfdClockRealtimeTest, ClockRealtime) {
-diff --git a/test/syscalls/linux/vdso_clock_gettime.cc b/test/syscalls/linux/vdso_clock_gettime.cc
-index ce1899f..05f3771 100644
---- a/test/syscalls/linux/vdso_clock_gettime.cc
-+++ b/test/syscalls/linux/vdso_clock_gettime.cc
-@@ -40,8 +40,6 @@ std::string PrintClockId(::testing::TestParamInfo<clockid_t> info) {
-       return "CLOCK_MONOTONIC";
-     case CLOCK_REALTIME:
-       return "CLOCK_REALTIME";
--    case CLOCK_BOOTTIME:
--      return "CLOCK_BOOTTIME";
-     default:
-       return absl::StrCat(info.param);
-   }
-@@ -98,8 +96,7 @@ TEST_P(CorrectVDSOClockTest, IsCorrect) {
- }
- 
- INSTANTIATE_TEST_SUITE_P(ClockGettime, CorrectVDSOClockTest,
--                         ::testing::Values(CLOCK_MONOTONIC, CLOCK_REALTIME,
--                                           CLOCK_BOOTTIME),
-+                         ::testing::Values(CLOCK_MONOTONIC, CLOCK_REALTIME),
-                          PrintClockId);
- 
- }  // namespace
 diff --git a/vdso/syscalls.h b/vdso/syscalls.h
 index b6d15a7..04cebd7 100644
 --- a/vdso/syscalls.h


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
